### PR TITLE
Add example for registering the ApplicationListener via spring.factories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ hs_err_pid*
 *.iml
 *.ipr
 *.iws
+.idea/
 
 .gradle/
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ configure(subprojects.findAll { println it.name; (it.name != 'api') }) {
 dependencies {
 	compile project(':api')
 	compile project(":by-application-listener")
+	compile project(":by-application-listener-with-spring-factories")
 	compile project(":by-active-profile")
 	compile project(":by-annotation")
 }

--- a/modules/by-application-listener-with-spring-factories/src/main/java/com/coderskitchen/example/by_application_listener_with_spring_factories/ByApplicationListenerWithSpringFactoriesExample.java
+++ b/modules/by-application-listener-with-spring-factories/src/main/java/com/coderskitchen/example/by_application_listener_with_spring_factories/ByApplicationListenerWithSpringFactoriesExample.java
@@ -1,0 +1,17 @@
+package com.coderskitchen.example.by_application_listener_with_spring_factories;
+
+import com.coderskitchen.example.ValuePrinter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "module4")
+@Setter
+public class ByApplicationListenerWithSpringFactoriesExample implements ValuePrinter {
+  private String myValue;
+
+  public void printValue() {
+    System.out.println(myValue);
+  }
+}

--- a/modules/by-application-listener-with-spring-factories/src/main/java/com/coderskitchen/example/by_application_listener_with_spring_factories/PropertyFilePatternRegisteringListener.java
+++ b/modules/by-application-listener-with-spring-factories/src/main/java/com/coderskitchen/example/by_application_listener_with_spring_factories/PropertyFilePatternRegisteringListener.java
@@ -1,0 +1,52 @@
+package com.coderskitchen.example.by_application_listener_with_spring_factories;
+
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.ResourcePropertySource;
+
+import java.io.IOException;
+
+public class PropertyFilePatternRegisteringListener implements ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+
+  public static final String PROPERTY_FILE_PREFIX = "application-module4";
+  private static final String FILE_SUFFIX = ".properties";
+
+  @Override
+  public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+    ConfigurableEnvironment environment = event.getEnvironment();
+    try {
+      loadProfileProperties(environment);
+      loadPlainProperties(environment);
+    } catch (IOException ex) {
+      throw new IllegalStateException("Unable to load configuration files", ex);
+    }
+  }
+
+  private void loadProfileProperties(ConfigurableEnvironment environment) throws IOException {
+    String[] activeProfiles = environment.getActiveProfiles();
+    if(activeProfiles != null && activeProfiles.length > 0)
+      loadProfileProperties(environment, activeProfiles);
+    else
+      loadProfileProperties(environment, environment.getDefaultProfiles());
+  }
+
+  private void loadProfileProperties(ConfigurableEnvironment environment, String[] profiles) throws IOException {
+    for (String activeProfile : profiles) {
+      addFileToEnvironment(environment, PROPERTY_FILE_PREFIX + "-" + activeProfile + FILE_SUFFIX);
+    }
+  }
+
+  private void loadPlainProperties(ConfigurableEnvironment environment) throws IOException {
+    addFileToEnvironment(environment, PROPERTY_FILE_PREFIX + FILE_SUFFIX);
+  }
+
+  private void addFileToEnvironment(ConfigurableEnvironment environment, String file) throws IOException {
+    ClassPathResource classPathResource = new ClassPathResource(file);
+    if (classPathResource.exists()) {
+      environment.getPropertySources()
+                 .addLast(new ResourcePropertySource(classPathResource));
+    }
+  }
+}

--- a/modules/by-application-listener-with-spring-factories/src/main/resources/META-INF/spring.factories
+++ b/modules/by-application-listener-with-spring-factories/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.context.ApplicationListener=com.coderskitchen.example.by_application_listener_with_spring_factories.PropertyFilePatternRegisteringListener

--- a/modules/by-application-listener-with-spring-factories/src/main/resources/application-module4-dev.properties
+++ b/modules/by-application-listener-with-spring-factories/src/main/resources/application-module4-dev.properties
@@ -1,0 +1,1 @@
+module4.myValue=By ApplicationListener registered via spring META-INF/spring.factories for DEVS

--- a/modules/by-application-listener-with-spring-factories/src/main/resources/application-module4.properties
+++ b/modules/by-application-listener-with-spring-factories/src/main/resources/application-module4.properties
@@ -1,0 +1,1 @@
+module4.myValue=By ApplicationListener registered via spring META-INF/spring.factories  

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-def modules = ['api', 'by-active-profile', 'by-annotation', 'by-application-listener']
+def modules = ['api', 'by-active-profile', 'by-annotation', 'by-application-listener', 'by-application-listener-with-spring-factories']
 
 modules.each { it ->
 	include it


### PR DESCRIPTION
With this example there is no need to create the `ApplicationListener` in the main module. 

I was not sure if you want me to update the current application listener, so I just added a new. Registering the `ApplicationListener` explicitly is also a good option (depending on what you want to achieve).